### PR TITLE
Path like access token key

### DIFF
--- a/cdn/README.md
+++ b/cdn/README.md
@@ -52,7 +52,7 @@ You need the following software installed,
 
    You have to specify an appropriate credential.
 
-2. Remember the S3 bucket name for GeoJSON files.
+2. Remember the S3 bucket name for GeoJSON files as `GEO_JSON_BUCKET`.
 
     ```
     GEO_JSON_BUCKET=`aws --query "Stacks[0].Outputs[?OutputKey=='GeoJsonBucketName']|[0].OutputValue" cloudformation describe-stacks --stack-name imaginary-map-geo-json-bucket | sed 's/^"//; s/"$//'`

--- a/cdn/continuous-delivery.md
+++ b/cdn/continuous-delivery.md
@@ -17,7 +17,7 @@ Please refer to [README.md](README.md#uploading-geojson-files).
 
 Suppose you have the following variable configured,
 - `GITHUB_ACCESS_TOKEN`: your generated GitHub personal access token
-- `GITHUB_ACCESS_TOKEN_KEY`; e.g., 'GITHUB_ACCESS_TOKEN_KEY=imaginary-map-github-access-token'
+- `GITHUB_ACCESS_TOKEN_KEY`; e.g., 'GITHUB_ACCESS_TOKEN_KEY=/development/imaginary-map/github/access-token'
 
 1. Create a secret.
 


### PR DESCRIPTION
Minor updates.
- The example of a GitHub personal access token in `continous-delivery.md` is replaced with a path like string.
- A minor fix in `README.md`.